### PR TITLE
parallel builds

### DIFF
--- a/recipe/build-libbasix.sh
+++ b/recipe/build-libbasix.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 cd cpp
 
+export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}
+
 # explicitly link cblas, since FindBLAS doesn't cover it,
 # but it's needed when building against netlib
 cmake \


### PR DESCRIPTION
not bumping build number, since this doesn't produce a new artifact. Just improving efficiency for the next round.