### PR TITLE
explicitly link libblas

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -10,6 +10,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libblas:
+- 3.8 *netlib
 libcblas:
 - 3.8 *netlib
 liblapack:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -8,6 +8,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libblas:
+- 3.8 *netlib
 libcblas:
 - 3.8 *netlib
 liblapack:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
 
 outputs:
   - name: fenics-libbasix
@@ -26,6 +26,7 @@ outputs:
         - make
         - pkg-config
       host:
+        - libblas
         - libcblas
         - liblapack
         - xtensor


### PR DESCRIPTION
not sure why link-inspector showed it not linked on staged-recipes, but it is shown in link inspector now

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
