### PR TITLE
prepare to rename feedstock fenics-basix

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -11,11 +11,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcblas:
-- 3.8 *netlib
+- 3.9 *netlib
 liblapack:
-- 3.8 *netlib
+- 3.9 *netlib
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -9,11 +9,11 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libblas:
-- 3.8 *netlib
+- 3.9 *netlib
 libcblas:
-- 3.8 *netlib
+- 3.9 *netlib
 liblapack:
-- 3.8 *netlib
+- 3.9 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ version: 2
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About fenics-basix-meta
-=======================
+About fenics-basix
+==================
 
 Home: https://fenicsproject.org
 
@@ -60,10 +60,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-fenics--basix-green.svg)](https://anaconda.org/conda-forge/fenics-basix) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/fenics-basix.svg)](https://anaconda.org/conda-forge/fenics-basix) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/fenics-basix.svg)](https://anaconda.org/conda-forge/fenics-basix) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/fenics-basix.svg)](https://anaconda.org/conda-forge/fenics-basix) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-fenics--libbasix-green.svg)](https://anaconda.org/conda-forge/fenics-libbasix) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/fenics-libbasix.svg)](https://anaconda.org/conda-forge/fenics-libbasix) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/fenics-libbasix.svg)](https://anaconda.org/conda-forge/fenics-libbasix) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/fenics-libbasix.svg)](https://anaconda.org/conda-forge/fenics-libbasix) |
 
-Installing fenics-basix-meta
-============================
+Installing fenics-basix
+=======================
 
-Installing `fenics-basix-meta` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `fenics-basix` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -149,17 +149,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating fenics-basix-meta-feedstock
-====================================
+Updating fenics-basix-feedstock
+===============================
 
-If you would like to improve the fenics-basix-meta recipe or build a new
+If you would like to improve the fenics-basix recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/fenics-basix-meta-feedstock are
+Note that all branches in the conda-forge/fenics-basix-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,5 +73,6 @@ about:
   dev_url: https://github.com/fenics/basix
 
 extra:
+  feedstock-name: fenics-basix
   recipe-maintainers:
     - minrk


### PR DESCRIPTION
this should have been the name, but I didn't know about the metadata when it was merged

I'll merge this and rename the repo once feedstock-outputs has been updated